### PR TITLE
Updated roles

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-title: BBC News Products and Systems
+title: BBC Digital Products
 ---
 # Join Us
 
@@ -13,15 +13,7 @@ We work in agile, lean, and flexible teams, with an innovating roadmap for News 
 
 ### London
 
-**[Software Engineering Team Lead - JS (React) - BBC News and World Service](https://careerssearch.bbc.co.uk/jobs/job/Software-Engineering-Team-Lead/30993)**
-
-Applications close **When the role is filled**
-
-### Glasgow
-
-**[Software Engineering Team Lead JS - BBC World Service](https://careerssearch.bbc.co.uk/jobs/job/Software-Engineering-Team-Lead-W2020/34232)**
-
-**[Two Senior Software Engineers - BBC World Service](https://careerssearch.bbc.co.uk/jobs/job/Senior-Software-Engineer-W2020/37942)**
+**[Software Engineer - JS (React) - BBC News and World Service x3](https://careerssearch.bbc.co.uk/jobs/job/Software-Engineer-React-BBC-News-C/41126)**
 
 Applications close **When the role is filled**
 


### PR DESCRIPTION
Removed the Glasgow and London SETL positions as they are now closed, and added the three London SE roles. Also updated the title to say `Digital Products` instead of `News Products and Systems`